### PR TITLE
fix: handle Brakeman exit code 5 and missing .node-version

### DIFF
--- a/.github/workflows/rails-test.yml
+++ b/.github/workflows/rails-test.yml
@@ -68,6 +68,10 @@ jobs:
         with:
           bundler-cache: true
 
+      - name: Ensure Node version file
+        if: inputs.node
+        run: test -f .node-version || echo "22" > .node-version
+
       - name: Set up Node.js
         if: inputs.node
         uses: actions/setup-node@v6

--- a/.github/workflows/ruby-ci.yml
+++ b/.github/workflows/ruby-ci.yml
@@ -41,7 +41,14 @@ jobs:
 
       - name: Scan for common Rails security vulnerabilities using static analysis
         if: inputs.brakeman
-        run: bin/brakeman --no-pager
+        run: |
+          rc=0
+          bin/brakeman --no-pager || rc=$?
+          if [ $rc -eq 5 ]; then
+            echo "::warning::Brakeman is not the latest version. Consider updating."
+            exit 0
+          fi
+          exit $rc
 
       - name: Scan for known security vulnerabilities in gems used
         if: inputs.bundler-audit


### PR DESCRIPTION
## Summary

- Brakeman exit code 5 ("not the latest version") is now a warning, not a failure
- `rails-test.yml` creates a default `.node-version` (v22) when the repo doesn't have one

Fixes CI failures in:
- keller-solutions/airport-code-quest#304 (`Security Scan (Ruby)` + `Test`)
- keller-solutions/kslabs-a11y-audit#231 (`Security Scan (Ruby)`)

## Type of Change

- [x] Bug fix

## Checklist

- [x] No secrets or credentials in code

🤖 Generated with [Claude Code](https://claude.com/claude-code)