### PR TITLE
fix(ci): harden reusable workflows against supply chain and injection attacks

### DIFF
--- a/.github/workflows/changelog-version-check.yml
+++ b/.github/workflows/changelog-version-check.yml
@@ -22,12 +22,14 @@ jobs:
 
       - name: Get PR version
         id: pr
+        env:
+          CHANGELOG_PATH: ${{ inputs.changelog-path }}
         run: |
           set -euo pipefail
-          VERSION=$(grep -m1 '^\## \[[0-9]' "${{ inputs.changelog-path }}" | sed 's/.*\[\(.*\)\].*/\1/')
+          VERSION=$(grep -m1 '^\## \[[0-9]' "$CHANGELOG_PATH" | sed 's/.*\[\(.*\)\].*/\1/')
 
           if [ -z "$VERSION" ]; then
-            echo "::error::Failed to extract version from ${{ inputs.changelog-path }}. Ensure a version entry exists."
+            echo "::error::Failed to extract version from $CHANGELOG_PATH. Ensure a version entry exists."
             exit 1
           fi
 
@@ -46,9 +48,11 @@ jobs:
 
       - name: Get main version
         id: main
+        env:
+          CHANGELOG_PATH: ${{ inputs.changelog-path }}
         run: |
           set -euo pipefail
-          CHANGELOG="main-branch/${{ inputs.changelog-path }}"
+          CHANGELOG="main-branch/$CHANGELOG_PATH"
           if [ -f "$CHANGELOG" ]; then
             VERSION=$(grep -m1 '^\## \[[0-9]' "$CHANGELOG" | sed 's/.*\[\(.*\)\].*/\1/')
             echo "version=$VERSION" >> $GITHUB_OUTPUT
@@ -57,10 +61,11 @@ jobs:
           fi
 
       - name: Compare versions
+        env:
+          PR_VERSION: ${{ steps.pr.outputs.version }}
+          MAIN_VERSION: ${{ steps.main.outputs.version }}
         run: |
           set -euo pipefail
-          PR_VERSION="${{ steps.pr.outputs.version }}"
-          MAIN_VERSION="${{ steps.main.outputs.version }}"
 
           echo "PR version: $PR_VERSION"
           echo "Main version: $MAIN_VERSION"

--- a/.github/workflows/changelog-version-check.yml
+++ b/.github/workflows/changelog-version-check.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Get PR version
         id: pr
@@ -39,7 +39,7 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Checkout main branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: main
           path: main-branch

--- a/.github/workflows/changelog-version-check.yml
+++ b/.github/workflows/changelog-version-check.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Get PR version
         id: pr
@@ -45,6 +47,7 @@ jobs:
         with:
           ref: main
           path: main-branch
+          persist-credentials: false
 
       - name: Get main version
         id: main

--- a/.github/workflows/rails-test.yml
+++ b/.github/workflows/rails-test.yml
@@ -61,10 +61,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd # v1
         with:
           bundler-cache: true
 
@@ -74,7 +74,7 @@ jobs:
 
       - name: Set up Node.js
         if: inputs.node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6
         with:
           node-version-file: .node-version
           cache: npm
@@ -97,13 +97,13 @@ jobs:
 
       - name: Upload coverage to Qlty
         if: inputs.qlty-coverage
-        uses: qltysh/qlty-action/coverage@v2
+        uses: qltysh/qlty-action/coverage@a19242102d17e497f437d7466aa01b528537e899 # v2
         with:
           token: ${{ secrets.QLTY_COVERAGE_TOKEN }}
           files: coverage/.resultset.json
 
       - name: Keep screenshots from failed system tests
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         if: failure()
         with:
           name: screenshots
@@ -138,10 +138,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd # v1
         with:
           bundler-cache: true
 
@@ -154,7 +154,7 @@ jobs:
         run: bin/rails test:system
 
       - name: Keep screenshots from failed system tests
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         if: failure()
         with:
           name: system-test-screenshots

--- a/.github/workflows/rails-test.yml
+++ b/.github/workflows/rails-test.yml
@@ -62,6 +62,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd # v1
@@ -139,6 +141,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd # v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
@@ -97,7 +97,7 @@ jobs:
       - name: Create Sentry release
         id: sentry
         if: steps.changelog.outputs.exists == 'false' && inputs.sentry
-        uses: getsentry/action-release@v3
+        uses: getsentry/action-release@dab6548b3c03c4717878099e43782cf5be654289 # v3
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
@@ -114,7 +114,7 @@ jobs:
       - name: Record New Relic deployment marker
         id: newrelic
         if: steps.changelog.outputs.exists == 'false' && inputs.new-relic
-        uses: newrelic/deployment-marker-action@v2.3.0
+        uses: newrelic/deployment-marker-action@8c1d1c009e7ee18ed2bda1e068d59867fdaa91c4 # v2.3.0
         with:
           apiKey: ${{ secrets.NEW_RELIC_API_KEY }}
           guid: ${{ secrets.NEW_RELIC_DEPLOYMENT_ENTITY_GUID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,12 +47,14 @@ jobs:
 
       - name: Extract version from CHANGELOG
         id: changelog
+        env:
+          CHANGELOG_PATH: ${{ inputs.changelog-path }}
         run: |
           set -euo pipefail
-          VERSION=$(grep -m1 '^\## \[[0-9]' "${{ inputs.changelog-path }}" | sed 's/.*\[\(.*\)\].*/\1/')
+          VERSION=$(grep -m1 '^\## \[[0-9]' "$CHANGELOG_PATH" | sed 's/.*\[\(.*\)\].*/\1/')
 
           if [ -z "$VERSION" ]; then
-            echo "Error: Failed to extract version from ${{ inputs.changelog-path }}" >&2
+            echo "Error: Failed to extract version from $CHANGELOG_PATH" >&2
             exit 1
           fi
 
@@ -71,12 +73,14 @@ jobs:
 
       - name: Extract release notes
         if: steps.changelog.outputs.exists == 'false'
+        env:
+          VERSION: ${{ steps.changelog.outputs.version }}
+          CHANGELOG_PATH: ${{ inputs.changelog-path }}
         run: |
           set -euo pipefail
-          VERSION="${{ steps.changelog.outputs.version }}"
           VERSION_ESCAPED=$(printf '%s\n' "$VERSION" | sed 's/[.[\*^$()+?{|]/\\&/g')
 
-          NOTES=$(awk "/^## \[$VERSION_ESCAPED\]/{found=1; next} /^## \[/{found=0} found" "${{ inputs.changelog-path }}")
+          NOTES=$(awk "/^## \[$VERSION_ESCAPED\]/{found=1; next} /^## \[/{found=0} found" "$CHANGELOG_PATH")
 
           if [ -z "$NOTES" ]; then
             NOTES="Release v$VERSION"
@@ -88,10 +92,11 @@ jobs:
         if: steps.changelog.outputs.exists == 'false'
         env:
           GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.changelog.outputs.version }}
         run: |
           set -euo pipefail
-          gh release create "v${{ steps.changelog.outputs.version }}" \
-            --title "v${{ steps.changelog.outputs.version }}" \
+          gh release create "v$VERSION" \
+            --title "v$VERSION" \
             --notes-file release_notes.md
 
       - name: Create Sentry release
@@ -128,4 +133,6 @@ jobs:
 
       - name: Skip release (tag exists)
         if: steps.changelog.outputs.exists == 'true'
-        run: echo "Tag v${{ steps.changelog.outputs.version }} already exists, skipping release creation"
+        env:
+          VERSION: ${{ steps.changelog.outputs.version }}
+        run: echo "Tag v$VERSION already exists, skipping release creation"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Extract version from CHANGELOG
         id: changelog

--- a/.github/workflows/ruby-ci.yml
+++ b/.github/workflows/ruby-ci.yml
@@ -32,10 +32,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd # v1
         with:
           bundler-cache: true
 
@@ -67,10 +67,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd # v1
         with:
           bundler-cache: true
 
@@ -86,15 +86,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd # v1
         with:
           bundler-cache: true
 
       - name: Prepare RuboCop cache
-        uses: actions/cache@v5
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
         env:
           DEPENDENCIES_HASH: ${{ hashFiles('.ruby-version', '**/.rubocop.yml', '**/.rubocop_todo.yml', 'Gemfile.lock') }}
         with:

--- a/.github/workflows/ruby-ci.yml
+++ b/.github/workflows/ruby-ci.yml
@@ -33,6 +33,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd # v1
@@ -68,6 +70,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd # v1
@@ -87,6 +91,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@09a7688d3b55cf0e976497ff046b70949eeaccfd # v1


### PR DESCRIPTION
## Summary

- Pin all 20 `uses:` references across 4 reusable workflows to specific commit SHAs to prevent supply chain attacks via mutable tags
- Move all `${{ }}` expressions out of `run:` shell blocks into `env:` mappings to prevent code injection via template expansion
- Add `persist-credentials: false` to all 8 `actions/checkout` steps to prevent GITHUB_TOKEN from persisting in `.git/config`

Resolves #2, resolves #4, resolves #5

## Test plan

- [ ] Verify CI passes on downstream repos after merge (reusable workflows referenced by SHA will resolve correctly)
- [ ] Re-run zizmor scan via Qlty to confirm all findings are resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)