### PR TITLE
fix(changelog-check): tolerate an unversioned CHANGELOG on main

### DIFF
--- a/.github/workflows/changelog-version-check.yml
+++ b/.github/workflows/changelog-version-check.yml
@@ -56,9 +56,12 @@ jobs:
         run: |
           set -euo pipefail
           CHANGELOG="main-branch/$CHANGELOG_PATH"
+          # A repo adopting the check may have a CHANGELOG on main with
+          # no version section yet (only [Unreleased]); treat that like
+          # a missing file rather than letting the grep pipeline fail.
           if [ -f "$CHANGELOG" ]; then
-            VERSION=$(grep -m1 '^\## \[[0-9]' "$CHANGELOG" | sed 's/.*\[\(.*\)\].*/\1/')
-            echo "version=$VERSION" >> $GITHUB_OUTPUT
+            VERSION=$(grep -m1 '^\## \[[0-9]' "$CHANGELOG" | sed 's/.*\[\(.*\)\].*/\1/' || true)
+            echo "version=${VERSION:-0.0.0}" >> $GITHUB_OUTPUT
           else
             echo "version=0.0.0" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
## Summary

First-time adopters hit a hard failure in the `Get main version` step: when main's CHANGELOG exists but has only an `[Unreleased]` section (no `## [x.y.z]` yet), the `grep | sed` pipeline exits non-zero under `set -euo pipefail` and the job dies before comparing anything. Surfaced adopting the check in keller-solutions/chronomap#46 (its first release PR introduces 1.0.0 while main is unversioned).

Fix: treat no-version-found the same as the missing-file case — default main's version to `0.0.0` so the adopting PR's version (e.g. 1.0.0) compares as greater and passes. Repos already carrying versioned changelogs are unaffected.

Verified by re-running the failing chronomap PR's check against this branch (chronomap temporarily pins its `uses:` ref to this branch; it flips back to `@main` once this merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)