### PR TITLE
chore(release): cut 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Guard against missing `bin/bundler-audit` and `package.json` in reusable workflows
 - Default `.node-version` fallback when file does not exist
 
-[Unreleased]: https://github.com/keller-solutions/.github/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/keller-solutions/.github/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/keller-solutions/.github/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/keller-solutions/.github/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/keller-solutions/.github/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-08-05
+
 ### Fixed
 
 - Org profile logo pointed at a hashed Astro asset that no longer exists, so the profile page rendered a broken image; now uses the stable `/assets/keller-solutions-logo.svg`


### PR DESCRIPTION
## Summary

Moves the org-profile fixes from #7 out of `[Unreleased]` and under `## [0.1.2] - 2026-08-05`, so the version can be tagged and released.

Once this merges I'll tag `v0.1.2` and create the GitHub Release, using the same conventions `release.yml` applies (tag `v$VERSION`, title `v$VERSION`, notes taken from the changelog section body).

**Patch, not minor.** The reusable workflows other repositories consume — `ruby-ci.yml`, `rails-test.yml`, `release.yml`, `changelog-version-check.yml` — are untouched. Only profile content changed, so nothing downstream is affected.

## Worth knowing

This repository has never actually cut a release. There are **no tags and no GitHub Releases**, even though `0.1.0` and `0.1.1` are both written into the CHANGELOG. `release.yml` is `workflow_call` only, so it runs for repositories that call it and never for this one — which is also why #7 ran zero checks.

Two follow-ups worth considering separately:

1. Add a small caller workflow here so pushes to `main` trigger this repo's own `release.yml`, making future releases automatic rather than manual.
2. Decide whether to backfill `v0.1.0` and `v0.1.1` tags at their original commits, or leave the gap and start the tag history at `v0.1.2`.

## Type of Change

- [x] Chore / dependency update

## Checklist

- [x] Tests pass (n/a — changelog only)
- [x] Linting passes (n/a)
- [x] CHANGELOG.md updated
- [x] No secrets or credentials in code

🤖 Generated with [Claude Code](https://claude.com/claude-code)