### PR TITLE
ci: hold this repo to the process it publishes

### DIFF
--- a/.github/workflows/self-ci.yml
+++ b/.github/workflows/self-ci.yml
@@ -1,0 +1,23 @@
+# Companion to self-release.yml. release.yml cuts a release from whatever
+# version sits at the top of CHANGELOG.md, so without this gate a PR could land
+# on main without a version bump and the release would silently no-op — which is
+# exactly what happened to 0.1.0 and 0.1.1, both written to the changelog and
+# never tagged.
+#
+# Named self-ci.yml because changelog-version-check.yml is the reusable workflow
+# this calls, and the two must not share a filename.
+
+name: Self CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  changelog:
+    uses: keller-solutions/.github/.github/workflows/changelog-version-check.yml@main

--- a/.github/workflows/self-release.yml
+++ b/.github/workflows/self-release.yml
@@ -1,0 +1,23 @@
+# This repository publishes the reusable workflows the rest of the org calls.
+# It should hold itself to the same process, so it calls its own release.yml
+# exactly the way every other repo does — by remote reference, not a local path,
+# so a break in the reusable workflow surfaces here first.
+#
+# Named self-release.yml rather than release.yml because the reusable workflow
+# already occupies that filename in this directory.
+
+name: Self Release
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    uses: keller-solutions/.github/.github/workflows/release.yml@main
+    permissions:
+      contents: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3] - 2026-08-05
+
+### Added
+
+- `self-release.yml` — this repository now calls its own `release.yml` on pushes to `main`, by the same remote reference every other repo uses, so releases are cut automatically instead of by hand
+- `self-ci.yml` — calls `changelog-version-check.yml` on pull requests, gating the version bump that `release.yml` depends on
+
 ## [0.1.2] - 2026-08-05
 
 ### Fixed
@@ -46,7 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Guard against missing `bin/bundler-audit` and `package.json` in reusable workflows
 - Default `.node-version` fallback when file does not exist
 
-[Unreleased]: https://github.com/keller-solutions/.github/compare/v0.1.2...HEAD
+[Unreleased]: https://github.com/keller-solutions/.github/compare/v0.1.3...HEAD
+[0.1.3]: https://github.com/keller-solutions/.github/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/keller-solutions/.github/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/keller-solutions/.github/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/keller-solutions/.github/releases/tag/v0.1.0


### PR DESCRIPTION
## Summary

This repository ships the reusable workflows the rest of the org calls, but has never run any of them on itself. Two consequences showed up today:

- **PR #7 merged with zero checks.** Nothing was watching.
- **`0.1.0` and `0.1.1` were never tagged or released**, despite both being written into the CHANGELOG months ago. `release.yml` is `workflow_call` only, so it fires for repos that call it and never for this one. I backfilled both releases by hand this morning, along with `v0.1.2`.

This adds the two callers that make the repo follow its own process.

### `self-release.yml`

Calls `release.yml` on pushes to `main`. Uses the same remote reference every other repo uses — `keller-solutions/.github/.github/workflows/release.yml@main` — rather than a local `./` path, so if the reusable workflow breaks, it breaks here first instead of in a client repo.

### `self-ci.yml`

Calls `changelog-version-check.yml` on pull requests. This is the necessary companion: `release.yml` cuts whatever version sits at the top of `CHANGELOG.md`, so without the gate a PR can land on `main` with no version bump and the release silently no-ops. That is precisely how the first two releases went missing.

Both are named `self-*` because the reusable workflows already occupy `release.yml` and `changelog-version-check.yml` in this directory.

### Version

Bumped to `0.1.3` with the link definition added, so `self-release.yml` has something to cut the moment it merges. That also makes this PR its own first test: if the wiring is right, merging it produces a `v0.1.3` release with no manual step.

## Type of Change

- [x] New feature

## Checklist

- [x] Tests pass (n/a — no test suite in this repo)
- [x] Linting passes (both workflow files validated as YAML)
- [x] CHANGELOG.md updated
- [x] No secrets or credentials in code

🤖 Generated with [Claude Code](https://claude.com/claude-code)