### PR TITLE
feat(workflows): reusable Copilot review request

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -1,0 +1,69 @@
+name: Copilot Review
+
+# Reusable: asks GitHub Copilot to review a pull request the moment it is opened (or leaves
+# draft), and never asks twice for the same head commit, because Copilot reviews are billed.
+#
+# Caller (in any repo):
+#   name: Copilot review
+#   on:
+#     pull_request:
+#       types: [opened, ready_for_review, reopened]
+#   permissions:
+#     pull-requests: write
+#   jobs:
+#     copilot:
+#       uses: keller-solutions/.github/.github/workflows/copilot-review.yml@main
+#
+# Add `synchronize` to the caller's types (and set re-review: true) only for repos where every
+# push should get a fresh review; the default economises by reviewing once per open.
+
+on:
+  workflow_call:
+    inputs:
+      re-review:
+        description: "Request a fresh review on every push (billed per review); default is once per open"
+        required: false
+        type: boolean
+        default: false
+      reviewer:
+        description: "Reviewer login to request"
+        required: false
+        type: string
+        default: "copilot-pull-request-reviewer[bot]"
+
+jobs:
+  request:
+    name: Request Copilot review
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Request the review
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          REVIEWER: ${{ inputs.reviewer }}
+          RE_REVIEW: ${{ inputs.re-review }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pr = context.payload.pull_request;
+            const reviewer = process.env.REVIEWER;
+            const login = reviewer.replace(/\[bot\]$/, "");
+
+            // Already reviewed this exact commit? Then there is nothing to ask for.
+            const reviews = await github.paginate(github.rest.pulls.listReviews, { owner, repo, pull_number: pr.number });
+            const onHead = reviews.some((r) => r.user?.login === login && r.commit_id === pr.head.sha);
+            if (onHead) { core.info(`${reviewer} already reviewed ${pr.head.sha}; skipping.`); return; }
+
+            // Reviewed an earlier commit and the caller did not opt into re-reviews? Leave it.
+            const everReviewed = reviews.some((r) => r.user?.login === login);
+            if (everReviewed && process.env.RE_REVIEW !== "true") { core.info(`${reviewer} reviewed an earlier commit; re-review is off.`); return; }
+
+            try {
+              await github.rest.pulls.requestReviewers({ owner, repo, pull_number: pr.number, reviewers: [reviewer] });
+              core.info(`Requested ${reviewer} on #${pr.number} (${pr.head.sha.slice(0, 7)}).`);
+            } catch (e) {
+              // Copilot not enabled on this repo, or the reviewer cannot be requested: say so, do not fail the PR.
+              core.warning(`Could not request ${reviewer}: ${e.message}. Is Copilot code review enabled for this repository?`);
+            }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Guard against missing `bin/bundler-audit` and `package.json` in reusable workflows
 - Default `.node-version` fallback when file does not exist
 
-[Unreleased]: https://github.com/keller-solutions/.github/compare/v0.1.2...HEAD
+[Unreleased]: https://github.com/keller-solutions/.github/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/keller-solutions/.github/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/keller-solutions/.github/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/keller-solutions/.github/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/keller-solutions/.github/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-08-21
+
+### Added
+
+- `copilot-review.yml` — reusable workflow that requests a GitHub Copilot review when a pull request is opened, leaves draft, or is reopened; skips if Copilot already reviewed the head commit, and only re-reviews on push when the caller opts in (`re-review: true`), since reviews are billed. First caller: ks-analytics-dashboard.
+
 ## [0.1.2] - 2026-08-05
 
 ### Fixed


### PR DESCRIPTION
## Summary
- `copilot-review.yml` (reusable, `workflow_call`): requests a Copilot review when a PR is opened, leaves draft, or is reopened. Skips if Copilot already reviewed the head commit; only re-reviews on push when the caller sets `re-review: true` (reviews are billed). Warns rather than fails when Copilot isn't enabled on the calling repo. `actions/github-script` pinned by SHA (v8), matching the other workflows here.
- CHANGELOG: 0.2.0 (minor: new reusable workflow).

Caller snippet is in the file header. First caller: `keller-solutions/ks-analytics-dashboard` (PR to follow).

Note: GitHub also offers this natively via a repository ruleset ("Automatically request Copilot code review"); this workflow is the version that works the same across every repo without per-repo ruleset clicks and documents the once-per-open economy.

## Checklist
- [x] YAML validated; SHA-pinned action
- [x] CHANGELOG bumped (version gate)
- [ ] Proven by the first caller's PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015XgnU5MS6CPWpZPqQw5x8k