### PR TITLE
ci: automatic Copilot review via keller-solutions/.github

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -1,0 +1,11 @@
+name: Copilot review
+# Org pattern: keller-solutions/.github/.github/workflows/copilot-review.yml. Reviews once per
+# open (billed); add `synchronize` here and `re-review: true` below to review every push.
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened]
+permissions:
+  pull-requests: write
+jobs:
+  copilot:
+    uses: keller-solutions/.github/.github/workflows/copilot-review.yml@main


### PR DESCRIPTION
## Summary
- `.github/workflows/copilot-review.yml` calls the org's reusable `copilot-review.yml` on `opened` / `ready_for_review` / `reopened`; no more per-PR API calls. `docs/PR-AUDIT.md` updated.
- Depends on keller-solutions/.github#10 being merged first; until then this caller's run fails to resolve the reusable workflow (expected).

This PR is also the proof: once #10 is in, reopening this PR should trigger the Copilot request without a manual call.

## Keller Solutions way
- ✓ DRY across repos: the process lives in the org repo once
- ✓ Cost: once per open by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015XgnU5MS6CPWpZPqQw5x8k